### PR TITLE
Async reset support for metazoan

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -295,7 +295,8 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   LatencyHistGuard guard(&zbd_->roll_latency_reporter_);
   zbd_->roll_qps_reporter_.AddCount(1);
 
-  new_meta_zone = zbd_->AllocateMetaZone();
+  new_meta_zone = zbd_->AllocateMetaZoneLocked(metadata_reset_mtx_);
+
   if (!new_meta_zone) {
     assert(false);  // TMP
     Error(logger_, "Out of metadata zones, we should go to read only now.");
@@ -312,6 +313,7 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   if (old_meta_zone->GetCapacityLeft()) WriteEndRecord(meta_log_.get());
   if (old_meta_zone->GetCapacityLeft()) old_meta_zone->Finish();
 
+  auto old_meta_log = std::move(meta_log_);
   meta_log_.reset(new_meta_log);
 
   std::string super_string;
@@ -327,7 +329,18 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   s = WriteSnapshotLocked(meta_log_.get());
 
   /* We've rolled successfully, we can reset the old zone now */
-  if (s.ok()) old_meta_zone->Reset();
+  if (s.ok()) {
+    std::thread backgroundTask([old_meta_log = std::move(old_meta_log), this] {
+      auto meta_zone = old_meta_log->GetZone();
+      std::unique_lock<std::mutex> lk(metadata_reset_mtx_);
+      meta_zone->Reset();
+
+      // metazone reset finished, notify the RollMetaZoneLocked() if any
+      metadata_cv_.notify_one();
+    });
+
+    backgroundTask.detach();
+  }
 
   auto new_meta_zone_size =
       meta_log_->GetZone()->wp_ - meta_log_->GetZone()->start_;

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -295,7 +295,7 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   LatencyHistGuard guard(&zbd_->roll_latency_reporter_);
   zbd_->roll_qps_reporter_.AddCount(1);
 
-  new_meta_zone = zbd_->AllocateMetaZoneLocked(metadata_reset_mtx_);
+  new_meta_zone = zbd_->AllocateMetaZone(metadata_reset_mtx_, metadata_reset_cv_);
 
   if (!new_meta_zone) {
     assert(false);  // TMP

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -127,6 +127,8 @@ class ZenFS : public FileSystemWrapper {
   std::unique_ptr<ZenMetaLog> meta_log_;
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> superblock_;
+  std::mutex metadata_reset_mtx_;
+  std::condition_variable metadata_cv_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -128,6 +128,7 @@ class ZenFS : public FileSystemWrapper {
   std::mutex metadata_sync_mtx_;
   std::unique_ptr<Superblock> superblock_;
   std::mutex metadata_reset_mtx_;
+  std::condition_variable metadata_reset_cv_;
   std::condition_variable metadata_cv_;
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -369,7 +369,7 @@ void ZoneFile::PushExtent() {
 }
 
 /* Assumes that data and size are block aligned */
-IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
+IOStatus ZoneFile::Append(void* data, int data_size, int valid_size, bool async) {
   uint32_t left = data_size;
   uint32_t wr_size, offset = 0;
   IOStatus s;
@@ -401,8 +401,13 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
     wr_size = left;
     if (wr_size > active_zone_->capacity_) wr_size = active_zone_->capacity_;
 
-    s = active_zone_->Append((char*)data + offset, wr_size);
-    if (!s.ok()) return s;
+    if (async) {
+      s = active_zone_->Append_async((char*)data + offset, wr_size); 
+      if (!s.ok()) return s;
+    
+    } else {
+      s = active_zone_->Append((char*)data + offset, wr_size); 
+    }
 
     fileSize += wr_size;
     left -= wr_size;
@@ -426,26 +431,44 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 
   buffered = _buffered;
   block_sz = zbd->GetBlockSize();
-  buffer_sz = block_sz * 256;
+  buffer_sz = block_sz * 32;
   buffer_pos = 0;
 
   zoneFile_ = zoneFile;
 
+  // TODO: add an Open() method so we can handle out of memory gracefully
   if (buffered) {
-    int ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), buffer_sz);
+    int ret;
 
-    if (ret) buffer = nullptr;
-
-    assert(buffer != nullptr);
+    ret = posix_memalign((void**)&b1, block_sz, buffer_sz);
+    assert(ret == 0);
+    ret = posix_memalign((void**)&b2, block_sz, buffer_sz);
+    assert(ret == 0);
+    (void)ret;
+    assert(b1 != nullptr && b2 != nullptr);
+  
+    buffer = b1;
   }
 
   metadata_writer_ = metadata_writer;
   zoneFile_->OpenWR();
 }
 
+IOStatus ZoneFile::Sync() {
+  IOStatus s;
+  if (active_zone_) {
+     s = active_zone_->Sync();
+    if (!s.ok()) return s;
+  }
+  return s;
+}
+
 ZonedWritableFile::~ZonedWritableFile() {
   zoneFile_->CloseWR();
-  if (buffered) free(buffer);
+  if (buffered) {
+    free(b1);
+    free(b2);
+  }
 };
 
 ZonedWritableFile::MetadataWriter::~MetadataWriter() {}
@@ -465,12 +488,14 @@ IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
 
   buffer_mtx_.lock();
   s = FlushBuffer();
-  buffer_mtx_.unlock();
-  if (!s.ok()) {
-    return s;
+  if (s.ok()) {
+    s = zoneFile_->Sync();
   }
+  buffer_mtx_.unlock();
+  
+  if (!s.ok()) return s;
+  
   zoneFile_->PushExtent();
-
   return metadata_writer_->Persist(zoneFile_);
 }
 
@@ -512,9 +537,19 @@ IOStatus ZonedWritableFile::FlushBuffer() {
   if (pad_sz) memset((char*)buffer + buffer_pos, 0x0, pad_sz);
 
   wr_sz = buffer_pos + pad_sz;
-  s = zoneFile_->Append((char*)buffer, wr_sz, buffer_pos);
+  s = zoneFile_->Append((char*)buffer, wr_sz, buffer_pos, true);
   if (!s.ok()) {
     return s;
+  }
+
+  s = zoneFile_->Sync();
+  if (!s.ok())
+    return s;
+
+  if (buffer == b1) {
+    buffer = b2;
+  } else {
+    buffer = b1;
   }
 
   wp += buffer_pos;

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -68,8 +68,10 @@ class ZoneFile {
   void CloseWR();
   bool IsOpenForWR();
 
-  IOStatus Append(void* data, int data_size, int valid_size);
+  IOStatus Append(void* data, int data_size, int valid_size, bool async = false);
   IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
+  IOStatus Sync();
+
   std::string GetFilename();
   void Rename(std::string name);
   time_t GetFileModificationTime();
@@ -159,7 +161,9 @@ class ZonedWritableFile : public FSWritableFile {
   IOStatus FlushBuffer();
 
   bool buffered;
-  char* buffer;
+  char *buffer;
+  char *b1;
+  char *b2;
   size_t buffer_sz;
   uint32_t block_sz;
   uint32_t buffer_pos;

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -82,7 +82,6 @@ uint64_t Zone::GetZoneNr() { return start_ / zbd_->GetZoneSize(); }
 void Zone::CloseWR() {
   assert(open_for_write_);
   Sync();
-  open_for_write_ = false;
 
   std::lock_guard<std::mutex> lock(zbd_->zone_resources_mtx_);
   if (Close().ok()) {

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -62,6 +62,15 @@ Zone::Zone(ZonedBlockDevice *zbd, struct zbd_zone *z)
   capacity_ = 0;
   if (!(zbd_zone_full(z) || zbd_zone_offline(z) || zbd_zone_rdonly(z)))
     capacity_ = zbd_zone_capacity(z) - (zbd_zone_wp(z) - zbd_zone_start(z));
+
+  memset(&wr_ctx.io_ctx, 0, sizeof(wr_ctx.io_ctx));
+  wr_ctx.fd = zbd_->GetWriteFD();
+  wr_ctx.iocbs[0] = &wr_ctx.iocb;
+  wr_ctx.inflight = 0; 
+
+  if (io_setup(1, &wr_ctx.io_ctx) < 0) {
+    fprintf(stderr, "Failed to allocate io context\n");
+ }
 }
 
 bool Zone::IsUsed() { return (used_capacity_ > 0) || open_for_write_; }
@@ -72,6 +81,7 @@ uint64_t Zone::GetZoneNr() { return start_ / zbd_->GetZoneSize(); }
 
 void Zone::CloseWR() {
   assert(open_for_write_);
+  Sync();
   open_for_write_ = false;
 
   std::lock_guard<std::mutex> lock(zbd_->zone_resources_mtx_);
@@ -158,10 +168,16 @@ IOStatus Zone::Append(char *data, uint32_t size) {
   uint32_t left = size;
   int fd = zbd_->GetWriteFD();
   int ret;
+  IOStatus s;
 
   if (capacity_ < size) return IOStatus::NoSpace("Not enough capacity for append");
 
   assert((size % zbd_->GetBlockSize()) == 0);
+
+  /* Make sure we don't have any outstanding writes */
+  s = Sync();
+  if (!s.ok())
+    return s;
 
   while (left) {
     ret = pwrite(fd, ptr, size, wp_);
@@ -172,6 +188,71 @@ IOStatus Zone::Append(char *data, uint32_t size) {
     capacity_ -= ret;
     left -= ret;
   }
+
+  return IOStatus::OK();
+}
+
+IOStatus Zone::Sync() {
+  struct io_event events[1];
+  struct timespec timeout;
+  int ret;
+  timeout.tv_sec = 1;
+  timeout.tv_nsec = 0;
+  
+  if (wr_ctx.inflight == 0)
+    return IOStatus::OK();
+
+  ret = io_getevents(wr_ctx.io_ctx, 1, 1, events, &timeout);
+  if (ret != 1) {
+    fprintf(stderr, "Failed to complete io - timeout ret: %d\n", ret);
+    return IOStatus::IOError("Failed to complete io - timeout?");
+  }
+
+  ret = events[0].res;
+  if (ret != (int)(wr_ctx.iocb.u.c.nbytes)) {
+    if (ret >= 0) {
+        /* TODO: we need to handle this case and keep on submittin' until we're done*/
+        fprintf(stderr, "failed to complete io - short write\n");
+        return IOStatus::IOError("Failed to complete io - short write");
+    } else {
+        return IOStatus::IOError("Failed to complete io - io error");
+    }
+  }
+
+  wr_ctx.inflight = 0; 
+
+  return IOStatus::OK();
+}
+
+IOStatus Zone::Append_async(char *data, uint32_t size) {
+  char *ptr = data;
+  uint32_t left = size;
+  int ret;
+  IOStatus s;
+
+  assert((size % zbd_->GetBlockSize()) == 0);
+  
+  /* Make sure we don't have any outstanding writes */
+  s = Sync();
+  if (!s.ok())
+    return s;
+
+  if (capacity_ < size)
+    return IOStatus::NoSpace("Not enough capacity for append");
+
+  io_prep_pwrite(&wr_ctx.iocb, wr_ctx.fd, data, size, wp_);
+
+  ret = io_submit(wr_ctx.io_ctx, 1, wr_ctx.iocbs);
+  if (ret < 0) {
+    fprintf(stderr, "Failed to submit io\n");
+    return IOStatus::IOError("Failed to submit io");
+  }
+
+  wr_ctx.inflight = size;  
+  ptr += size;
+  wp_ += size;
+  capacity_ -= size;
+  left -= size;
 
   return IOStatus::OK();
 }

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -642,13 +642,17 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   // We reserve one more free zone for WAL files in case RocksDB delay close WAL files.
   int reserved_zones = 1;
 
-  LatencyHistGuard guard_total;
-  LatencyHistGuard guard_actual;
-  
   auto *reporter_total = is_wal ? &io_alloc_wal_latency_reporter_
           : &io_alloc_non_wal_latency_reporter_;
 
   guard_total.count_now(reporter_total);
+  LatencyHistGuard guard_wal;
+  LatencyHistGuard guard_non_wal;
+  LatencyHistGuard guard_wal_actual;
+  LatencyHistGuard guard_non_wal_actual;
+
+  guard_non_wal.count_now(&io_alloc_non_wal_latency_reporter_);
+  guard_wal.count_now(&io_alloc_wal_latency_reporter_);
 
   io_alloc_qps_reporter_.AddCount(1);
 

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -651,9 +651,6 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime, bool 
   LatencyHistGuard guard_wal_actual;
   LatencyHistGuard guard_non_wal_actual;
 
-  guard_non_wal.count_now(&io_alloc_non_wal_latency_reporter_);
-  guard_wal.count_now(&io_alloc_wal_latency_reporter_);
-
   io_alloc_qps_reporter_.AddCount(1);
 
   auto t0 = std::chrono::system_clock::now();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <libaio.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -33,6 +34,14 @@ namespace ROCKSDB_NAMESPACE {
 
 class ZonedBlockDevice;
 
+struct zenfs_aio_ctx {
+  struct iocb iocb;
+  struct iocb *iocbs[1];
+  io_context_t io_ctx;
+  int inflight;
+  int fd;
+};
+
 class Zone {
   ZonedBlockDevice *zbd_;
 
@@ -46,12 +55,15 @@ class Zone {
   bool open_for_write_;
   Env::WriteLifeTimeHint lifetime_;
   std::atomic<long> used_capacity_;
+  struct zenfs_aio_ctx wr_ctx;
 
   IOStatus Reset();
   IOStatus Finish();
   IOStatus Close();
 
   IOStatus Append(char *data, uint32_t size);
+  IOStatus Append_async(char *data, uint32_t size);
+  IOStatus Sync();
   bool IsUsed();
   bool IsFull();
   bool IsEmpty();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -125,6 +125,7 @@ class ZonedBlockDevice {
   Zone *GetIOZone(uint64_t offset);
 
   Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
+  Zone *AllocateMetaZoneLocked(std::mutex& metadata_reset_mtx);
   Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -125,8 +125,7 @@ class ZonedBlockDevice {
   Zone *GetIOZone(uint64_t offset);
 
   Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
-  Zone *AllocateMetaZoneLocked(std::mutex& metadata_reset_mtx);
-  Zone *AllocateMetaZone();
+  Zone *AllocateMetaZone(std::mutex& metadata_reset_mtx, std::condition_variable& cv);
 
   uint64_t GetFreeSpace();
   uint64_t GetUsedSpace();

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,3 +1,3 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
 zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/zbd_stat.h
-zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg
+zenfs_LDFLAGS = -lzbd -laio -u zenfs_filesystem_reg


### PR DESCRIPTION
This PR adds async support for metadata reset. I would like to get some initial feedback and then make official PR to dev branch (also deleting the debug related changes).
- changes the metazone allocation from 3 to 4
- In the backend Reset(), the thread will first acquire a lock and release the lock after successful reset
- In the frontend AllocateMetaZone(), once the thread finds no available metazone, it will wait for the Reset() to finish and release the lock.
-  Reset() is dispatched asynchronously in an thread in RollMetaZoneLocked().

Note: this PR will cause disk wipeout command failed. Inspecting in progress. 